### PR TITLE
Update join page

### DIFF
--- a/content/join/index.md
+++ b/content/join/index.md
@@ -12,9 +12,10 @@ menu:
 Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSdYilTsg74EZCh2_5G6dPtNd0z3EQv4Pc63brUUpM1XMQkzMg/viewform?usp=sf_link)
 if you are interested in contributing to the Open Programmable Infrastructure
 Project. Once you have filled out the participation form you will be added to
-the contact sheet and have access to edit it. You can then join any desired
-subgroup by adding an `x` to the appropriate box. Also, it will help to email
-the group leader to make sure you are included in invites.
+the contact sheet and have access to edit it. Please join our Slack and
+introduce yourself into the subgroups where you may want to contribute. Once
+you join a particular subgroup’s slack channel, you can ask the group lead to
+add you to the meeting invites for that particular sub group.
 
 # OPI Project Membership
 

--- a/content/join/index.md
+++ b/content/join/index.md
@@ -7,6 +7,22 @@ menu:
     weight: 1
 ---
 
+# Contributing to the OPI Project
+
+Please fill out [this form](https://docs.google.com/forms/d/e/1FAIpQLSdYilTsg74EZCh2_5G6dPtNd0z3EQv4Pc63brUUpM1XMQkzMg/viewform?usp=sf_link)
+if you are interested in contributing to the Open Programmable Infrastructure
+Project. Once you have filled out the participation form you will be added to
+the contact sheet and have access to edit it. You can then join any desired
+subgroup by adding an `x` to the appropriate box. Also, it will help to email
+the group leader to make sure you are included in invites.
+
+## Request New Member Orientation
+
+To receive an orientation briefing for the project and more information on how
+to join or contribute, fill out [this form](https://forms.gle/25NbAw9UHtKnygQWA).
+
+# OPI Project Membership
+
 Open Programmable Infrastructure would not exist without the support of the
-member organizations. If your organization is interested in joining, please
-[click here](https://enrollment.lfx.linuxfoundation.org/?project=opifund).
+member organizations. If your organization or company is interested in joining,
+please [click here](https://enrollment.lfx.linuxfoundation.org/?project=opifund).

--- a/content/join/index.md
+++ b/content/join/index.md
@@ -16,11 +16,6 @@ the contact sheet and have access to edit it. You can then join any desired
 subgroup by adding an `x` to the appropriate box. Also, it will help to email
 the group leader to make sure you are included in invites.
 
-## Request New Member Orientation
-
-To receive an orientation briefing for the project and more information on how
-to join or contribute, fill out [this form](https://forms.gle/25NbAw9UHtKnygQWA).
-
 # OPI Project Membership
 
 Open Programmable Infrastructure would not exist without the support of the


### PR DESCRIPTION
This udpates the join page to differntiate the two types of "Join"
actions we see for OPI:

* Contributors joining the project
* Companies becoming members via the Linux Foundation

Signed-off-by: Kyle Mestery <mestery@mestery.com>