### PR TITLE
subprojects: Add subprojects header

### DIFF
--- a/content/subprojects/index.md
+++ b/content/subprojects/index.md
@@ -1,0 +1,14 @@
+---
+title: "Subprojects"
+description: ""
+featured_image: '/images/opi_logos/backgrounds/OPI_logo_social_dark.png'
+menu:
+  main:
+    weight: 1
+---
+
+#  Open Programmable Infrastructure Subprojects
+
+The current list of official subprojects for OPI is as follows:
+
+* [IPDK](https://ipdk.io)


### PR DESCRIPTION
This adds an official subproject header to the OPI website. The current
list of subprojects is limited to IPDK.

Subprojects are different than subgroups [1]. However, I'm curious what
folks think about this and want to get feedback before merging this.

[1] https://github.com/opiproject/opi/blob/main/SUBGROUPS.md

Signed-off-by: Kyle Mestery <mestery@mestery.com>