### PR TITLE
linters: Add markdown linter

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,17 @@
+name: Linters
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+  workflow_dispatch:
+
+jobs:
+  markdown-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run tests
+        run: docker run -v $PWD:/workdir ghcr.io/igorshubovych/markdownlint-cli:latest --ignore=themes --disable=MD013 --disable=MD025 "**/*.md"

--- a/content/join/index.md
+++ b/content/join/index.md
@@ -17,7 +17,7 @@ introduce yourself into the subgroups where you may want to contribute. Once
 you join a particular subgroup’s slack channel, you can ask the group lead to
 add you to the meeting invites for that particular sub group.
 
-# OPI Project Membership
+## OPI Project Membership
 
 Open Programmable Infrastructure would not exist without the support of the
 member organizations. If your organization or company is interested in joining,

--- a/content/members/index.md
+++ b/content/members/index.md
@@ -11,14 +11,14 @@ Thank you to our member companies for sponsoring the OPI Project.
 
 Premier members of the OPI Project are listed below.
 
-![Dell Logo](/images/logos/dell-inc.svg)   
-![F5 Logo](/images/logos/f5-networks-inc.svg)   
+![Dell Logo](/images/logos/dell-inc.svg)
+![F5 Logo](/images/logos/f5-networks-inc.svg)
 
-![Intel Logo](/images/logos/intel-corporation.svg)   
+![Intel Logo](/images/logos/intel-corporation.svg)
 
-![Keysight Technologies Logo](/images/logos/keysight.png)   
+![Keysight Technologies Logo](/images/logos/keysight.png)
 
-![Marvell Logo](/images/logos/marvell-asia-pte-ltd.svg)   
+![Marvell Logo](/images/logos/marvell-asia-pte-ltd.svg)
 
-![NVIDIA Logo](/images/logos/nvidia-inc.svg)   
-![Red Hat Logo](/images/logos/red-hat-inc.svg)   
+![NVIDIA Logo](/images/logos/nvidia-inc.svg)
+![Red Hat Logo](/images/logos/red-hat-inc.svg)

--- a/content/posts/2022-03-18-opi-event.md
+++ b/content/posts/2022-03-18-opi-event.md
@@ -3,104 +3,105 @@ title: "Videos and Slides From OPI Event"
 date: 2022-03-17T15:06:30-06:00
 ---
 
+# Open Programmable Infrastructure Alpha Event
+
 The Open Programmable Infrastructure Alpha Event was a great success thanks to
 all of our presentors. We had great participation. See below for all of the
 videos and slides, which are hosted on the [IPDK YouTube page](https://www.youtube.com/channel/UCrabFf05cRQgbmmk7aLzlJQ).
 
-# Day One
+## Day One
 
-## OPI Event Keynote: Nick McKeown
+### OPI Event Keynote: Nick McKeown
 
 {{< youtube qi-BaWXfrqg >}}
 [OPI Event Keynote](/presentations/OPI_Event_Intro_Keynote_Intel_Nick_McKeown.pdf)
 
-## OPI Event Keynote: AI Training Clusters: Challenges @ DC Scale - Meta - Nic Viljoen
+### OPI Event Keynote: AI Training Clusters: Challenges @ DC Scale - Meta - Nic Viljoen
 
 {{< youtube wew6in1i8kc >}}
 [AI Training Clusters: Challenges @ DC Scale Slides](/presentations/OPI_Event_Meta_Nic_Viljoen.pdf)
 
-## OPIEvent - D/IPU Open API, The need for a Common Interface Framework - Dell Mark Sanders
+### OPIEvent - D/IPU Open API, The need for a Common Interface Framework - Dell Mark Sanders
 
 {{< youtube lONRPj19-PA >}}
 [D/IPU Open API, The need for a Common Interface Framework Slides](/presentations/OPI_Event_Dell_Mark_Sanders.pdf)
 
-## OPI Event - IPDK and its role in enabling Open Programmable Infrastructure - Dan Daly
+### OPI Event - IPDK and its role in enabling Open Programmable Infrastructure - Dan Daly
 
 {{< youtube eeEcxMUP45A >}}
 
-## OPIEvent - Data Access in an Open Prog. Infra. World - LightBits - Muli Ben-Yehuda
+### OPIEvent - Data Access in an Open Prog. Infra. World - LightBits - Muli Ben-Yehuda
 
 {{< youtube UmhbUvcRUwM >}}
 [Data Access in an Open Prog. Infra. World Slides](/presentations/OPI_Event_Lightbits_Muli_BenYehuda.pdf)
 
-## OPIEvent - MLOps Meets Programmable Infrastructure - Nutanix - Debo Dutta
+### OPIEvent - MLOps Meets Programmable Infrastructure - Nutanix - Debo Dutta
 
 {{< youtube pLfh0S0XpTE >}}
 [MLOps Meets Programmable Infrastructure Slides](/presentations/OPI_Event_Nutanix_Debo.pdf)
 
-## OPIEvent - How Prog. Infra. Can Enable Better Edge Computing - Cisco - Ian Wells
+### OPIEvent - How Prog. Infra. Can Enable Better Edge Computing - Cisco - Ian Wells
 
 {{< youtube vqC3zhhS2v4 >}}
 [How Prog. Infra. Can Enable Better Edge Computing Slides](/presentations/OPI_Event_Cisco_Ian_Wells.pdf)
 
-## OPIEvent - DPU Disruption of Today’s Infrastructure Paradigm - F5 - Tim Michels
+### OPIEvent - DPU Disruption of Today’s Infrastructure Paradigm - F5 - Tim Michels
 
 {{< youtube HwvP3Doyxdc >}}
 [DPU Disruption of Today’s Infrastructure Paradigm Slides](/presentations/OPI_Event_F5_Tim_Michels.pdf)
 
-## OPI Event - Programmability and Composability for an e2e Networking Evolution VMware Pere & Ben Pfaff
+### OPI Event - Programmability and Composability for an e2e Networking Evolution VMware Pere & Ben Pfaff
 
 {{< youtube HrC5MMJQO8A >}}
 [Programmability and Composability for an e2e Networking Evolution Slides](/presentations/OPI_Event_VMWare_Ben_Pere.pdf)
 
-## OPI Event - Next Steps in Community Building/Evolution - Kris Murphy (RH), Paul Pindell (F5), Kyle Mestery (Intel)
+### OPI Event - Next Steps in Community Building/Evolution - Kris Murphy (RH), Paul Pindell (F5), Kyle Mestery (Intel)
 
 {{< youtube R3MmC_DrE2Y >}}
 [Next Steps in Community Building/Evolution Slides](/presentations/next-steps-community.pdf)
 
-# Day Two
+## Day Two
 
-## OPI Event Day 2 Keynote - IBM - Denis Kennelly, Vincent Hsu
+### OPI Event Day 2 Keynote - IBM - Denis Kennelly, Vincent Hsu
 
 {{< youtube I9yU9sshTpQ >}}
 [OPI Event Day 2 Keynote - IBM Slides](/presentations/OPI_Event_IBM_Keynote_Denis_Vincent.pdf)
 
-## OPI Event - Telco needs of IPDK, Cloud, HW, and SW suppliers - Ericsson Tomas Fredberg
+### OPI Event - Telco needs of IPDK, Cloud, HW, and SW suppliers - Ericsson Tomas Fredberg
 
 {{< youtube pl2cR6gfc0A >}}
 [Telco needs of IPDK, Cloud, HW, and SW suppliers Slides](/presentations/OPI_Event_Ericsson_Tomas_Fredberg.pdf)
 
-## OPI Event - The Importance of Testing In Your Open Source Infra - Spirent - Tom Nadeau
+### OPI Event - The Importance of Testing In Your Open Source Infra - Spirent - Tom Nadeau
 
 {{< youtube iVF0zff7FFM >}}
 [The Importance of Testing In Your Open Source Infra Slides](/presentations/OPI_Event_Spirent_Tom_Nadeau.pdf)
 
-## OPI Event - Programmable Test Infrastructure for Prog. Infra. - Keysight - Ankur Sheth
+### OPI Event - Programmable Test Infrastructure for Prog. Infra. - Keysight - Ankur Sheth
 
 {{< youtube mB_aTg9DNkk >}}
 [Programmable Test Infrastructure for Prog. Infra. Slides](/presentations/OPI_Event_Keysight_Ankur_Sheth.pdf)
 
-## OPI Event - The Importance of Hybrid Cloud + OPI - Red Hat - Kris Murphy, Billy McFall
+### OPI Event - The Importance of Hybrid Cloud + OPI - Red Hat - Kris Murphy, Billy McFall
 
 {{< youtube 3kDAZK29wco >}}
 [The Importance of Hybrid Cloud + OPI Slides](/presentations/OPI_Event_Red_Hat_Kris_Billy.pdf)
 
-## OPI Event - Target Abstraction Breakout - Marvell, Intel
+### OPI Event - Target Abstraction Breakout - Marvell, Intel
 
 {{< youtube 1P8KiHq9AwI >}}
 [Target Abstraction Breakout Slides](/presentations/OPI_Event_Target_Abstraction_Breakout.pdf)
 
-## OPI Event - Application Abstraction Breakout - F5 - Joel Moses
+### OPI Event - Application Abstraction Breakout - F5 - Joel Moses
 
 {{< youtube 5PXKvRcdXJE >}}
 
-## OPI Event - Lifecycle Breakout - Kris Murphy (Red Hat) Mark Sanders, Boris Glimcher (Dell)
+### OPI Event - Lifecycle Breakout - Kris Murphy (Red Hat) Mark Sanders, Boris Glimcher (Dell)
 
 {{< youtube dFjxDXTxgxg >}}
 [Lifecycle Breakout Slides](/presentations/OPI_Event_Breakout3_Lifecycle_API_Prov_Mgt.pdf)
 
-## OPI Event Closing - Kyle Mestery (Intel), Kris Murphy (Red Hat), Paul Pindell (F5)
+### OPI Event Closing - Kyle Mestery (Intel), Kris Murphy (Red Hat), Paul Pindell (F5)
 
 {{< youtube BnzWDIZEywI >}}
 [Closing Thoughts Slides](/presentations/OPI_Event_Closing_thoughts.pdf)
-

--- a/content/posts/2022-06-21-opi-launch-press-release.md
+++ b/content/posts/2022-06-21-opi-launch-press-release.md
@@ -3,11 +3,11 @@ title: "Linux Foundation Announces Open Programmable Infrastructure Project to D
 date: 2022-06-21T05:06:30-06:00
 ---
 
-_Data Processing and Infrastructure Processing Units – DPU and IPU – are changing the way enterprises deploy and manage compute resources across their networks; OPI will nurture an ecosystem to enable easy adoption of these innovative technologies_
+# Data Processing and Infrastructure Processing Units – DPU and IPU – are changing the way enterprises deploy and manage compute resources across their networks; OPI will nurture an ecosystem to enable easy adoption of these innovative technologies
 
-SAN FRANCISCO, Calif.,  – June 21, 2022 – The Linux Foundation, the nonprofit organization enabling mass innovation through open source, today announced the new Open Programmable Infrastructure (OPI) Project. OPI will foster a community-driven, standards-based open ecosystem for next-generation architectures and frameworks based on DPU and IPU technologies. OPI is designed to facilitate the simplification of network, storage and security APIs within applications to enable more portable and performant applications in the cloud and datacenter across DevOps, SecOps and NetOps. 
+SAN FRANCISCO, Calif.,  – June 21, 2022 – The Linux Foundation, the nonprofit organization enabling mass innovation through open source, today announced the new Open Programmable Infrastructure (OPI) Project. OPI will foster a community-driven, standards-based open ecosystem for next-generation architectures and frameworks based on DPU and IPU technologies. OPI is designed to facilitate the simplification of network, storage and security APIs within applications to enable more portable and performant applications in the cloud and datacenter across DevOps, SecOps and NetOps.
 
-Founding members of OPI include Dell Technologies, F5, Intel, Keysight Technologies, Marvell, NVIDIA and Red Hat with a growing number of contributors representing a broad range of leading companies in their fields ranging from silicon and device manufactures, ISVs, test and measurement partners, OEMs to end users. 
+Founding members of OPI include Dell Technologies, F5, Intel, Keysight Technologies, Marvell, NVIDIA and Red Hat with a growing number of contributors representing a broad range of leading companies in their fields ranging from silicon and device manufactures, ISVs, test and measurement partners, OEMs to end users.
   
 “When new technologies emerge, there is so much opportunity for both technical and business innovation but barriers often include a lack of open standards and a thriving community to support them,” said Mike Dolan, senior vice president of Projects at the Linux Foundation. “DPUs and IPUs are great examples of some of the most promising technologies emerging today for cloud and datacenter, and OPI is poised to accelerate adoption and opportunity by supporting an ecosystem for DPU and IPU technologies.”
 
@@ -15,45 +15,44 @@ DPUs and IPUs are increasingly being used to support high-speed network capabili
 
 OPI will help establish and nurture an open and creative software ecosystem for DPU and IPU-based infrastructures. As more DPUs and IPUs are offered by various vendors, the OPI Project seeks to help define the architecture and frameworks for the DPU and IPU software stacks that can be applied to any vendor's hardware offerings. The OPI Project also aims to foster a rich open source application ecosystem, leveraging existing open source projects, such as DPDK, SPDK, OvS, P4, etc., as appropriate.  The project intends to:
 
-* Define DPU and IPU, 
-* Delineate vendor-agnostic frameworks and architectures for DPU- and IPU-based software stacks applicable to any hardware solutions, 
+* Define DPU and IPU,
+* Delineate vendor-agnostic frameworks and architectures for DPU- and IPU-based software stacks applicable to any hardware solutions,
 * Enable the creation of a rich open source application ecosystem,
-* Integrate with existing open source projects aligned to the same vision such as the Linux kernel, and, 
+* Integrate with existing open source projects aligned to the same vision such as the Linux kernel, and,
 * Create new APIs for interaction with, and between, the elements of the DPU and IPU ecosystem, including hardware, hosted applications, host node, and the remote provisioning and orchestration of software
-* With several working groups already active, the initial technology contributions will come in the form of the Infrastructure Programmer Development Kit (IPDK) that is now an official sub-project of OPI governed by the Linux Foundation. IPDK is an open source framework of drivers and APIs for infrastructure offload and management that runs on a CPU, IPU, DPU or switch. 
-* In addition, NVIDIA DOCA, an open source software development framework for NVIDIA’s BlueField DPU, will be contributed to OPI to help developers create applications that can be offloaded, accelerated, and isolated across DPUs, IPUs, and other hardware platforms. 
+* With several working groups already active, the initial technology contributions will come in the form of the Infrastructure Programmer Development Kit (IPDK) that is now an official sub-project of OPI governed by the Linux Foundation. IPDK is an open source framework of drivers and APIs for infrastructure offload and management that runs on a CPU, IPU, DPU or switch.
+* In addition, NVIDIA DOCA, an open source software development framework for NVIDIA’s BlueField DPU, will be contributed to OPI to help developers create applications that can be offloaded, accelerated, and isolated across DPUs, IPUs, and other hardware platforms.
 
-For more information visit: https://opiproject.org; start contributing here: https://github.com/opiproject/opi.
+For more information visit: [opiproject](https://opiproject.org); start contributing here: [opiproject github](https://github.com/opiproject/opi).
 
-**Founding Member Comments**   
+## Founding Member Comments
 
-***Geng Lin, EVP and Chief Technology Officer, F5***   
+***Geng Lin, EVP and Chief Technology Officer, F5***
 “The emerging DPU market is a golden opportunity to reimagine how infrastructure services can be deployed and managed. With collective collaboration across many vendors representing both the silicon devices and the entire DPU software stack, an ecosystem is emerging that will provide a low friction customer experience and achieve portability of services across a DPU enabled infrastructure layer of next generation data centers, private clouds, and edge deployments.”
 
-***Patricia Kummrow, CVP and GM, Ethernet Products Group, Intel***   
-"Intel is committed to open software to advance collaborative and competitive ecosystems and is pleased to be a founding member of the Open Programmable Infrastructure project, as well as fully supportive of the Infrastructure Processor Development Kit (IPDK) as part of OPI. We look forward to advancing these tools, with the Linux Foundation, fulfilling the need for a programmable infrastructure across cloud, data center, communication and enterprise industries making it easier for developers to accelerate innovation and advance technological developments."
+***Patricia Kummrow, CVP and GM, Ethernet Products Group, Intel***
+"Intel is committed to open software to advance collaborative and competitive ecosystems and is pleased to be a founding member of the Open Programmable Infrastructure project, as well as fully supportive of the Infrastructure Processor Development Kit (IPDK) as part of OPI. We look forward to advancing these tools, with the Linux Foundation, fulfilling the need for a programmable infrastructure across cloud, data center, communication and enterprise industries making it easier for developers to accelerate innovation and advance technological developments.
 
-***Ram Periakaruppan, VP and General Manager, Network Test and Security Solutions Group, Keysight Technologies***   
+***Ram Periakaruppan, VP and General Manager, Network Test and Security Solutions Group, Keysight Technologies***
 “Programmable infrastructure built with DPUs/IPUs enables significant innovation for networking, security, storage and other areas in disaggregated cloud environments. As a founding member of the Open Programmable Infrastructure Project, we are committed to providing our test and validation expertise as we collaboratively develop and foster a standards-based open ecosystem that furthers infrastructure development, enabling cloud providers to maximize their investment.”
 
-***Cary Ussery, Vice President, Software and Support, Processors, Marvell***   
+***Cary Ussery, Vice President, Software and Support, Processors, Marvell***
 "Data center operators across multiple industry segments are increasingly incorporating DPUs as an integral part of their infrastructure processing to offload complex workloads from general purpose to more robust compute platforms. Marvell strongly believes that software standardization in the ecosystem will significantly contribute to the success of workload acceleration solutions. As a founding member of the OPI Project, Marvell aims to address the need for standardization of software frameworks used in provisioning, lifecycle management, orchestration, virtualization and deployment of workloads."
 
-***Kevin Deierling, vice president of Networking at NVIDIA***   
+***Kevin Deierling, vice president of Networking at NVIDIA***
 “The fundamental architecture of data centers is evolving to meet the demands of private and hyperscale clouds and AI, which require extreme performance enabled by DPUs such as the NVIDIA BlueField and open frameworks such as NVIDIA DOCA. These will support OPI to provide BlueField users with extreme acceleration, enabled by common, multi-vendor management and applications. NVIDIA is a founding member of the Linux Foundation’s Open Programmable Infrastructure Project to continue pushing the boundaries of networking performance and accelerated data center infrastructure while championing open standards and ecosystems.”
 
-***Erin Boyd, director of emerging technologies, Red Hat***   
+***Erin Boyd, director of emerging technologies, Red Hat***
 “As a founding member of the Open Programmable Infrastructure project, Red Hat is committed to helping promote, grow and collaborate on the emergent advantage that new hardware stacks can bring to the cloud-native community, and we believe that the formalization of OPI into the Linux Foundation is an important step toward achieving this in an open and transparent fashion. Establishing an open standards-based ecosystem will enable us to create fully programmable infrastructure, opening up new possibilities for better performance, consumption, and the ability to more easily manage unique hardware at scale.”
 
-**About the Linux Foundation**   
+**About the Linux Foundation**
 Founded in 2000, the Linux Foundation and its projects are supported by more than 1,800 members and is the world’s leading home for collaboration on open source software, open standards, open data, and open hardware. Linux Foundation’s projects are critical to the world’s infrastructure including Linux, Kubernetes, Node.js, Hyperledger, RISC-V, and more.  The Linux Foundation’s methodology focuses on leveraging best practices and addressing the needs of contributors, users and solution providers to create sustainable models for open collaboration. For more information, please visit us at linuxfoundation.org.
- 
- 
+
 The Linux Foundation has registered trademarks and uses trademarks. For a list of trademarks of The Linux Foundation, please see its trademark usage page: www.linuxfoundation.org/trademark-usage. Linux is a registered trademark of Linus Torvalds. Red Hat is a registered trademark of Red Hat, Inc. or its subsidiaries in the U.S. and other countries.
 
-_Marvell Disclaimer: This press release contains forward-looking statements within the meaning of the federal securities laws that involve risks and uncertainties. Forward-looking statements include, without limitation, any statement that may predict, forecast, indicate or imply future events or achievements. Actual events or results may differ materially from those contemplated in this press release. Forward-looking statements speak only as of the date they are made. Readers are cautioned not to put undue reliance on forward-looking statements, and no person assumes any obligation to update or revise any such forward-looking statements, whether as a result of new information, future events or otherwise._
+_Marvell Disclaimer: This press release contains forward-looking statements within the meaning of the federal securities laws that involve risks and uncertainties. Forward-looking statements include, without limitation, any statement that may predict, forecast, indicate or imply future events or achievements. Actual events or results may differ materially from those contemplated in this press release. Forward-looking statements speak only as of the date they are made. Readers are cautioned not to put undue reliance on forward-looking statements, and no person assumes any obligation to update or revise any such forward-looking statements, whether as a result of new information, future events or otherwise.
 
-Media Contact   
-Carolyn Lehman   
-The Linux Foundation   
-clehman@linuxfoundation.org   
+Media Contact
+Carolyn Lehman
+The Linux Foundation
+clehman@linuxfoundation.org


### PR DESCRIPTION
This adds a markdownlinter to the opiproject website GitHub repository.

Also fixes the existing linting errors for a clean run.

Signed-off-by: Kyle Mestery <mestery@mestery.com>