### PR TITLE
Change to non-expiring slack invite link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,4 +16,4 @@ copyright = "Copyright the Open Programmable Infrastructure Fund"
 
 [[params.ananke_socials]]
   name = "slack"
-  url = "https://join.slack.com/t/opi-project/shared_invite/zt-1aywl9qia-MOumVXg3g9dpRfahlW5l0w"
+  url = "https://join.slack.com/t/opi-project/shared_invite/zt-1ctqtrgkz-WJZrcVPp3P1ACZWjpZP2KQ"


### PR DESCRIPTION
Slack added the option to use a non-expiring slack invite link.
Signed-off-by: Paul Pindell <ppindell@gmail.com>