### PR TITLE
subgroups: Add subgroups website

### DIFF
--- a/content/subgroups/index.md
+++ b/content/subgroups/index.md
@@ -1,0 +1,182 @@
+---
+title: "Subgroups"
+description: ""
+featured_image: '/images/opi_logos/backgrounds/OPI_logo_social_dark.png'
+menu:
+  main:
+    weight: 1
+---
+
+## Organization Group
+
+* Description & Responsibilities
+  * The Org group exists to facilitate the general administration of the
+    OPI Project’s shared files, membership information, group deliverables,
+    main meeting, main meeting agenda, meeting minutes, meeting recordings,
+    GitHub rights, and community standards.
+* Alignment to project goal(s)
+  * The Organization group is helping to create a community-driven standards-
+    based open ecosystem for DPU/IPU-like technologies.
+* Leader
+  * Paul Pindell
+* Meeting Time & Date
+  * Mondays 9-9:30am PT
+* Slack Channel
+  * [org-subgroup](https://opi-project.slack.com/archives/C032L8R9Y2F)
+* Status
+  * Active
+
+## Vision Statement/Goals group
+
+* Description & Responsibilities
+  * Maintain Vision Statement and Goals Documents
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * Yan Fisher
+* Meeting Time & Date
+  * Every other Monday at 11am-12pm PT
+* Slack Channel
+  * [vision-subgroup](https://opi-project.slack.com/archives/C0344U70R8W)
+* Status
+  * Active
+
+## Developer Platform/PoC/Reference Architecture group
+
+* Description & Responsibilities
+  * Create a developer platform for producing applications that run on
+    DPU/IPU devices
+* Customer-driven vendor-neutral approach to PoC development
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * Steven Royer
+* Meeting Time & Date
+  * Wednesdays 11am-12pm PT
+* Slack Channel
+  * [poc-subgroup](https://opi-project.slack.com/archives/C033E418VCK)
+* Status
+  * Active
+
+## Minimum Requirements group
+
+* Description & Responsibilities
+  * This group is defining a set of minimum requirements for D/IPU devices
+    that the OPI Project software frameworks and APIs will interoperate
+    with.  Devices that do not meet these requirements may still use the
+    OPI Project components, but there may be deficiencies due to missing
+    capabilities in the base hardware platform.
+* Alignment to project goal(s) -- N/A
+* Leader
+  * Tim Michels
+* Meeting Time & Date
+  * None
+* Status
+  * A set of requirements has been defined
+  * Moving the HW capabilities work and spreadsheet over to the API
+    sub-group
+  * Disbanded
+
+## Legal/Governance group
+
+* Description & Responsibilities
+  * Setting up governance model
+  * Choosing a foundation to join
+    * Linux Foundation
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * Yan Fisher
+* Meeting Time & Date
+  * Wednesdays 9:00-9:45am PT
+* Slack Channel:
+  * [goverance-subgroup](https://opi-project.slack.com/archives/C03390HJL8Y)
+* Status
+  * Active
+
+## Provisioning and Platform Management Group
+
+* Description & Responsibilities
+  * [Discovery & Provisioning](https://github.com/opiproject/opi-prov-life/blob/main/PROVISIONING.md)
+  * [Inventory](https://github.com/opiproject/opi-prov-life/blob/main/INVENTORY.md)
+  * Boot sequencing
+  * Lifecycle & Updates
+  * [Monitoring & Telemetry](https://github.com/opiproject/opi-prov-life/blob/main/MONITORING.md)
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * [Boris Glimcher](https://github.com/glimchb)
+* Meeting Time & Date
+  * Tuesdays 13:00-13:45 ET
+* Slack Channel
+  * [lifecycle-subgroup](https://opi-project.slack.com/archives/C0342L6T7EC)
+* Status
+  * Active
+
+## Open Programmable Infrastructure API and Behavioral Model
+
+* Description & Responsibilities
+  * Define the object models for each of the components and services on the
+    D/IPU
+  * Both host system facing and control/management facing
+  * Taxonomy: network, security, storage, ai/ml, gateway, …
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * Mark Sanders
+* Meeting Time & Date
+  * Thursdays 12:00-1:00pm ET (9:00-10:00am PT)
+* Slack Channel
+  * [open-api-subgroup](https://opi-project.slack.com/archives/C0344KMEAKB)
+* Status
+  * Active
+
+## Use Case
+
+* Description & Responsibilities
+  * Create an open channel with the end users and potential deployment partners.
+  * Share the work being done by the subgroups and get feedback from the end users
+      and deployment partners.
+  * Encourage more end users and deployment partners to contribute, take part, and join.
+* Alignment to project goal(s)
+  * By engaging with and seeking input from end users and deployment partners,
+      the Use Case subgroup will help by validating the implementation examples,
+      architectures, and APIs being worked on in the other subgroups.
+  * This will also help build the open community to include additional
+    contributors and members.
+* Leader
+  * Elad Blatt
+* Meeting Time & Date
+  * TBD
+* Slack Channel
+  * [use-case-subgroup](https://opi-project.slack.com/archives/C038BL2KFFU)
+* Status
+  * Active
+
+## Events and Outreach
+
+* Description & Responsibilities
+  * The charter of the subgroup is to plan, coordinate, and execute DB
+    community and other industry events as well as lead outreach, marketing,
+    and PR activities for DB
+* Alignment to project goal(s)
+  * Establish an open community to support vendor-independent and jointly
+    co-developed ecosystem.
+* Leader
+  * Paul Pindell
+* Meeting Time & Date
+  * Wednesdays 7:30-8:00am PT
+* Slack Channel
+  * [events-subgroup](https://opi-project.slack.com/archives/C03462BB1PC)
+* Status
+  * Active
+
+## Orientation
+
+* Description & Responsibilities
+  * Coordinate overtures to new participants
+  * Maintain orientation documents
+* Alignment to project goal(s) -- Workgroup leader: Please update this bullet
+* Leader
+  * Kris Murphy
+* Meeting Time & Date
+  * TBD
+* Slack Channel
+  * [orientation-subgroup](https://opi-project.slack.com/archives/C03366FT5GW)
+* Status
+  * Active


### PR DESCRIPTION
This moves the content from [1] to the website.

[1] https://github.com/opiproject/opi/blob/main/SUBGROUPS.md

Signed-off-by: Kyle Mestery <mestery@mestery.com>