### PR TITLE
posts: Fix weirdness with Posts page

### DIFF
--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -6,9 +6,6 @@
     <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-60" }}">
       {{ partial "site-navigation.html" .}}
       <div class="tc-l pv4 pv6-l ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
-          {{ .Title | default .Site.Title }}
-        </h1>
         {{ with .Params.description }}
           <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
             {{ . }}


### PR DESCRIPTION
Since we do not use Titles anywhere, just remove it from the CSS for now. This fixes the issue with the word `Posts` sitting on top of the OPI image on the Posts page.

Signed-off-by: Kyle Mestery <mestery@mestery.com>